### PR TITLE
fix upgrade overlay and cupcake formula

### DIFF
--- a/ponyclicker.css
+++ b/ponyclicker.css
@@ -673,6 +673,7 @@ a:hover {
   box-shadow:         inset 0 0 20px #b0b0b0 !important;
   border: 1px #bbb solid !important;
   margin: 1px !important;
+  opacity: 0.5;
   cursor: default !important;
 }
 #achievements .hidden {

--- a/ponyclicker.js
+++ b/ponyclicker.js
@@ -210,7 +210,7 @@ var ponyclicker = (function(){
   // -------------------------------- Game Loading and Settings --------------------------------
   //
   function predictcupcakes() {
-    return Math.floor(Math.pow(inv_triangular((Game.legacysmiles + Game.totalsmiles)/1000000000000000000), 0.618)) - Game.cupcakes;
+    return Math.floor(Math.pow(inv_triangular((Game.legacysmiles + Game.totalsmiles)/1000000000000000000)-1, 0.618)) - Game.cupcakes;
   }
   function ResetGame() {
     for(var i = 0; i < Game.pinkies.length; ++i) {
@@ -228,7 +228,7 @@ var ponyclicker = (function(){
     Game.legacysmiles += Game.totalsmiles;
     Game.legacyclicks += Game.clicks;
     var diff = Game.cupcakes;
-    Game.cupcakes = Math.floor(Math.pow(inv_triangular(Game.legacysmiles/1000000000000000000), 0.618));
+    Game.cupcakes = Math.floor(Math.pow(inv_triangular(Game.legacysmiles/1000000000000000000)-1, 0.618));
     diff = Game.cupcakes - diff;
     ShowNotice("Game reset", ((diff==0)?null:"You get <b>" + Pluralize(diff, " cupcake") + "</b> for your <b>" + Pluralize(Game.totalsmiles, " smile") + "</b>"), null);
     Game.resets += 1;

--- a/ponyclicker.js
+++ b/ponyclicker.js
@@ -1644,7 +1644,7 @@ var ponyclicker = (function(){
     item = -1;
     actualTop = $('#storeupgrades')[0].offsetTop-wrapper.scrollTop+wrapper.offsetTop;
     if((event.clientX>wrapper.offsetLeft) && (event.clientY>actualTop) && (!mobile || event.clientY>wrapper.offsetTop)) {
-      item = Math.floor((event.clientY - actualTop)/52)*6 + Math.floor((event.clientX - wrapper.offsetLeft)/52);
+      item = Math.floor((event.clientY - actualTop)/54)*6 + Math.floor((event.clientX - wrapper.offsetLeft - 4)/54);
     }
     UpdateUpgradeOverlay(item, event.clientX, event.clientY);
 


### PR DESCRIPTION
Fixes #95 
My first time working with git and I couldn't quite figure out if you can split several commits to one branch into separate pull requests, so I made it a package deal. The changes are somewhat minor so I hope it's not a problem.

1. I found out why the tooltip for upgrades changed too quickly to the next one and managed to fix it. Should switch pixel perfect now.
2. Not affordable upgrades were hard to distinguish from affordable ones, so I added opacity, much like Cookie Clicker.
3. The cupcakes formula was slightly off and gave one cupcake from the very beginning and the second one at 1 quintillion. The difference quickly converges to zero the more cupcakes you have, so the impact on gameplay is minuscule, but still ...