### PR TITLE
require complete friend graphs for that achievement

### DIFF
--- a/ponyclicker.js
+++ b/ponyclicker.js
@@ -824,7 +824,7 @@ var ponyclicker = (function(){
     ["Best Buds", "Camaraderie Crusaders", "Inner Circle", "Friend-Of-The-Month Club", "No Pony Left Behind", "Reference Chart Not Optional"],
     [2,3,6,12,18,24],
     function(n) { return 'Have at least <b>'+n+' ponies</b> and a completed friendship graph.'; },
-    function(n) { return function(){ return (Game.store[0]>=n) && (Game.store[1] >= triangular(n)); }; }
+    function(n) { return function(){ return (Game.store[0]>=n) && (Game.store[1] >= triangular(Game.store[0])); }; }
   ));
    
   achievements_shop.push('234'); // Fixer Upper achievement


### PR DESCRIPTION
Current behavior simply asks the user to produce at least the number of ponies and friendships required to create a complete graph, however a player can still attain this achievement by not creating a complete graph, by going to the next number of nodes in the graph and adding the number of edges required to make the graph with the previous number of nodes a complete graph, however, doing it this way means the player's current graph is not complete